### PR TITLE
Start creating a deploy preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,10 +3,6 @@ name: Deploy Preview
 on:
   workflow_dispatch:
     inputs:
-      repository:
-        description: "Repository to target. Format is user/repository"
-        required: true
-        type: text
       pull_request:
         description: "The Pull request to target for the deploy-preview"
         required: true
@@ -22,4 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run a one-line script
-        run: echo Hello, world!
+        run: "echo Repo trigger: ${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,7 +13,8 @@ on:
         type: text
 
 jobs:
-  build:
+  preview:
+    if: ${{ inputs.authentication }} == ${{ secrets.AUTH }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,25 @@
+name: Deploy Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Repository to target. Format is user/repository"
+        required: true
+        type: text
+      pull_request:
+        description: "The Pull request to target for the deploy-preview"
+        required: true
+        type: text
+      authentication:
+        description: "The secret to authorize this action run"
+        required: true
+        type: text
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run a one-line script
+        run: echo Hello, world!


### PR DESCRIPTION
This is the start of a new system to manage deploy previews.

The idea is to use the new behaviour that Actions can now trigger a `workflow_dispatch` action using the default `GITHUB_TOKEN`

The system would allow triggering this action from another repository using a secret as authentication to make sure only allowed repositories can use this action.

Still WIP as I need to wrap my head around the workflow_dispatch system.